### PR TITLE
Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,22 @@ var toolWindow = new ToolWindow({
   height: 250, // starting height
   minWidth: 150, // don't go thinner than this
   minHeight: 200, // don't go shorter than this
+  //closeButtonText:  "\u2716", // ✖
+  //placement: "inside,auto",
+  //relativeToElement: "#container",
+  //animated: true,
+  //animationTime: 1000,
   content: {
     // simple text content -- you can also use "html" or "url" (more on that later) 
     type: "text",
-    content: "Hello World!"
+    value: "Hello World!"
   },
   title: "Demo window", // goes in the title bar,
   buttons: [{
-    title: "Dismiss",
+    text: "Dismiss",
     clicked: function() {
         // button click handlers are invoked with the toolwindow as the `this` parameter
-        this.close();
+        this.hide();
       }
     }, {
       text: "Refresh",
@@ -49,10 +54,12 @@ var toolWindow = new ToolWindow({
         // - string
         // - function producing a string
         // - async function producing a string (ie, promise)
+        this.title = 'New title of demo window';
         this.content = {
           type: "html",
           value: "<hr/>This is html<hr/>"
         };
+        //this.fitContent(); 
         this.refresh();
       }
     }]

--- a/dist/toolwindow.css
+++ b/dist/toolwindow.css
@@ -77,8 +77,7 @@ Use this as a template for toolwindow styling
 	background: red;
 }
 .dialog button.hover,
-.dialog button.active
-{
+.dialog button.active {
 	cursor: pointer;
 }
 .dialog .button-bar button {

--- a/dist/toolwindow.css
+++ b/dist/toolwindow.css
@@ -55,6 +55,7 @@ Use this as a template for toolwindow styling
 	bottom: 0;
     width: 100%;
 	text-align: right;
+	user-select: none; /* no select/copy to clipboard */
 }
 .dialog button.close {
     color: CaptionText;
@@ -70,6 +71,7 @@ Use this as a template for toolwindow styling
 	height: 32px;
 	width: 32px;
     cursor: pointer;
+	user-select: none; /* no select/copy to clipboard */
 }
 .dialog button.close:hover {
 	background: red;

--- a/dist/toolwindow.js
+++ b/dist/toolwindow.js
@@ -23,7 +23,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
   }, { "./lib/toolwindow": 4 }], 2: [function (require, module, exports) {
     var defaultOptions = {
       title: "Tool Window",
-      closeButtonText: "\u2716", //## ✖ = &#x2716; = \u2716
+      closeButtonText: "\u2716", // ✖ = &#x2716; = \u2716
       buttons: [{
         text: "Ok",
         clicked: function clicked() {
@@ -78,10 +78,8 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
        */
       horizontalEdge: "horizontalEdge",
       /**
-       * alignment: horizontalEdge //## text not ok
-       *   outside the element, but vertically horizontalEdge-aligned
-       *   - so top-right has the top the dialog in-line with the top of the element and
-       *      the dialog is to the right of the element
+       * alignment: verticalEdge
+       *   outside the element, but vertically verticalEdge-aligned
        */
       verticalEdge: "verticalEdge"
     };
@@ -240,6 +238,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
      *
      * Originally designed by ZulNs, @Gorontalo, Indonesia, 7 June 2017
      * Modified to be a re-usable component by Davyd McColl, 2019
+     * Extended to allow selecting and copying content by Frank Buchholz, 2019
      */
 
     var _require2 = require("./config"),
@@ -277,17 +276,15 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
       // TODO: determine auto position?
 
-	  //## Calculate minimal width to show all buttons 
-      //## this._minW = this._options.minWidth;
-	  //## CSS: .dialog .button-bar button { min-width: 64px; padding: 0 5px; border: 1px; margin: 5px; }
-	  //## The following formula works well even if it's too narrow in the beginning.
-	  //## The width gets extended in fitContent() -> ctx.self.moveTo()
-      this._minW = Math.max(this._options.minWidth, 
+	  // Calculate minimal width to show all buttons
+	  // CSS: .dialog .button-bar button { min-width: 64px; padding: 0 5px; border: 1px; margin: 5px; }
+	  // The following formula works even if it's too narrow in the beginning.
+	  // The width gets extended as required in fitContent() -> ctx.self.moveTo() later
+      this._minW = Math.max(this._options.minWidth,
 		+ this._options.buttons.length * 64			// min-width: 64px;
 		+ this._options.buttons.length * (2 * 5)	// margin: 5px;
-		- 49	// I've no idea why this value woks as needed (it's independent from count of buttons)
+		- 49	// 'Magic' value works perfectly fine if content of popup is small
 	  );
-console.log(this._options.buttons.length + ' ' + this._minW);	  
 	  this._log('#buttons='+this._options.buttons.length+' minWidth='+this._options.minWidth+' _minW='+this._minW);
       this._minH = this._options.minHeight;
       if (this._options.width < this._minW) {
@@ -304,7 +301,6 @@ console.log(this._options.buttons.length + ' ' + this._minW);
       this._resizeMode = '';
       this._initialPlacementDone = false;
       this._raised = false;
-	  //## this._handlingMouseEvent = false; //## not used
 
       if (this._options.boundingElement) {
         this._boundingElement = typeof this._options.boundingElement === "string" ? document.querySelector(this._options.boundingElement) : this._options.boundingElement;
@@ -313,22 +309,19 @@ console.log(this._options.buttons.length + ' ' + this._minW);
       this._createDialogStructure();
       this._bindMouseEvents();
 
-      // TODO: fix this magick -- should probably be calculated on first show,
-      //  once the buttons are actually rendered
-      //## this._minW = Math.max(this._minW, (this._buttons.length - 1) * 84 + 13); //## already done
-
       this._shownCount = 0;
     }
 
     ToolWindow.prototype = {
-	  _log: function(text){if(false)console.log(text)}, // show log if true	
-      get title() { //## Allow to set the title	
+	  _log: function(text){if(window.__debug_toolwindow__)console.log(text);}, // show log if true
+	  
+      get title() {
         return this._options.title;
       },
-      set title(value) { //## Allow to set the title	
+      set title(value) {
         this._options.title = value;
       },
-	  
+
       get content() {
         return this._options.content;
       },
@@ -350,7 +343,7 @@ console.log(this._options.buttons.length + ' ' + this._minW);
         // TODO: optionally determine initial placement from
         //  a provided event object
 
-        var autoFocus = this._buttons[this._buttons.length - 1]; //## Why the second button from the right?
+        var autoFocus = this._buttons[this._buttons.length - 1];
         if (autoFocus) {
           autoFocus.focus();
         }
@@ -417,10 +410,10 @@ console.log(this._options.buttons.length + ' ' + this._minW);
         }, frameTime);
       },
       refresh: function refresh() {
-        var _this3 = this;
+        var _self = this;
 
-        if (this._options.title && this._options.title != "") { //## Update title
-		  _this3._setTitle(this._options.title);
+        if (this._options.title) {
+		  _self._setTitle(this._options.title);
 		}
         if (!this._options.content) {
           this._setText("No content defined");
@@ -429,13 +422,13 @@ console.log(this._options.buttons.length + ' ' + this._minW);
         switch (this._options.content.type) {
           case "text":
             this._fetchContent(function (result) {
-              return _this3._setText(result);
+              return _self._setText(result);
             });
             break;
           case "html":
           case "text/html":
             this._fetchContent(function (result) {
-              return _this3._setHTML(result);
+              return _self._setHTML(result);
             });
             break;
           case "url":
@@ -741,7 +734,7 @@ console.log(this._options.buttons.length + ' ' + this._minW);
         }
         return current + delta;
       },
-      _setTitle: function _setTitle(text) { //## Set title
+      _setTitle: function _setTitle(text) {
         this._dialogTitleText.innerHTML = "";
         if (typeof text !== "string") {
           text = (text || "").toString();
@@ -810,10 +803,10 @@ console.log(this._options.buttons.length + ' ' + this._minW);
       },
       _createTitlebar: function _createTitlebar() {
         this._dialogTitle = this._mkDiv("titlebar", this._dialog);
-        this._closeButton = this._mkEl("button", "close", this._dialogTitle); //##change oder of elements to allow copy to clipboard for content plus title
+        this._closeButton = this._mkEl("button", "close", this._dialogTitle);
         this._closeButton.innerText = this._options.closeButtonText;
         this._closeButton.addEventListener("click", this.hide.bind(this));
-        this._dialogTitleText = this._mkEl("span", "", this._dialogTitle); //## Allow to set title
+        this._dialogTitleText = this._mkEl("span", "", this._dialogTitle);
         this._dialogTitleText.innerText = this._options.title;
       },
       _createContentArea: function _createContentArea() {
@@ -912,7 +905,6 @@ console.log(this._options.buttons.length + ' ' + this._minW);
         }
       },
       _suppressEvent: function _suppressEvent(evt) {
-		//this._log('_suppressEvent: '+(this._isDrag?' Drag':'')+(this._isResize?' resize=':'')+this._resizeMode+(this._isButton?' Button':''));		
 		if (evt.stopPropagation) {
           evt.stopPropagation();
         }
@@ -929,9 +921,9 @@ console.log(this._options.buttons.length + ' ' + this._minW);
         if (!evt || !evt.target) {
           return;
         }
-		this._log('_onMouseDown: '+(this._isDrag?' Drag':'')+(this._isResize?' resize=':'')+this._resizeMode+(this._isButton?' Button':''));		
+		this._log('_onMouseDown: '+(this._isDrag?' Drag':'')+(this._isResize?' resize=':'')+this._resizeMode+(this._isButton?' Button':''));
 
-		if (evt.target.closest(".dialog>.content") && this._resizeMode === '') { //## Allow normal events on content element
+		if (!this._resizeMode && evt.target.closest(".dialog>.content")) { // Allow normal events on content element
 			return;
 		}
         var rect = this._getOffset(this._dialog);
@@ -950,9 +942,7 @@ console.log(this._options.buttons.length + ' ' + this._minW);
         this._leftPos = rect.left;
         this._topPos = rect.top;
 
-		//## Allow to set title
-        //if (evt.target === this._dialogTitle && this._resizeMode === '') {
-        if ((evt.target === this._dialogTitle || evt.target === this._dialogTitleText) && this._resizeMode === '') {
+        if (!this._resizeMode && (evt.target === this._dialogTitle || evt.target === this._dialogTitleText)) {
           this._setCursor('move');
           this._isDrag = true;
         } else if (this._resizeMode !== '') {
@@ -1157,7 +1147,6 @@ console.log(this._options.buttons.length + ' ' + this._minW);
         if (!evt || !evt.target) {
           return;
         }
-		this._log('_onMouseMove: '+(this._isDrag?' Drag':'')+(this._isResize?' resize':'')+this._resizeMode+(this._isButton?' Button':''));		
 
         if (this._isDrag) {
           this._doDrag(evt);
@@ -1196,16 +1185,16 @@ console.log(this._options.buttons.length + ' ' + this._minW);
             this._resizeMode = '';
           }
         }
-		this._log('_onMouseMove: '+(this._isDrag?' Drag':'')+(this._isResize?' resize':'')+this._resizeMode+(this._isButton?' Button':''));		
-       if (!this._isDrag && !this._isResize && this._resizeMode==='' && !this._isButton) { //## Allow normal events like 'extend selection' on content element and events on external objects like 'change slider'
+		this._log('_onMouseMove: '+(this._isDrag?' Drag':'')+(this._isResize?' resize=':'')+this._resizeMode+(this._isButton?' Button':''));		
+		if (!this._isDrag && !this._isResize && !this._resizeMode && !this._isButton) { // Allow normal events like 'extend selection' on content element and events on external objects
           return;
         }
         return this._suppressEvent(evt);
       },
       _onMouseUp: function _onMouseUp(evt) {
         evt = evt || window.event;
-		this._log('_onMouseUp: '+(this._isDrag?' Drag':'')+(this._isResize?' resize':'')+this._resizeMode+(this._isButton?' Button':''));		
-       if (!this._isDrag && !this._isResize && this._resizeMode==='' && !this._isButton) { //## Allow normal events like 'extend selection' on content element and events on external objects like 'change slider'
+		this._log('_onMouseUp: '+(this._isDrag?' Drag':'')+(this._isResize?' resize=':'')+this._resizeMode+(this._isButton?' Button':''));		
+       if (!this._isDrag && !this._isResize && !this._resizeMode && !this._isButton) { // Allow normal events like 'extend selection' on content element and events on external objects
           return;
         }
         if (this._isDrag) {

--- a/dist/toolwindow.js
+++ b/dist/toolwindow.js
@@ -23,7 +23,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
   }, { "./lib/toolwindow": 4 }], 2: [function (require, module, exports) {
     var defaultOptions = {
       title: "Tool Window",
-      closeButtonText: "✖",
+      closeButtonText: "\u2716", //## ✖ = &#x2716; = \u2716
       buttons: [{
         text: "Ok",
         clicked: function clicked() {
@@ -78,7 +78,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
        */
       horizontalEdge: "horizontalEdge",
       /**
-       * alignment: horizontalEdge
+       * alignment: horizontalEdge //## text not ok
        *   outside the element, but vertically horizontalEdge-aligned
        *   - so top-right has the top the dialog in-line with the top of the element and
        *      the dialog is to the right of the element
@@ -277,7 +277,18 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
       // TODO: determine auto position?
 
-      this._minW = this._options.minWidth;
+	  //## Calculate minimal width to show all buttons 
+      //## this._minW = this._options.minWidth;
+	  //## CSS: .dialog .button-bar button { min-width: 64px; padding: 0 5px; border: 1px; margin: 5px; }
+	  //## The following formula works well even if it's too narrow in the beginning.
+	  //## The width gets extended in fitContent() -> ctx.self.moveTo()
+      this._minW = Math.max(this._options.minWidth, 
+		+ this._options.buttons.length * 64			// min-width: 64px;
+		+ this._options.buttons.length * (2 * 5)	// margin: 5px;
+		- 49	// I've no idea why this value woks as needed (it's independent from count of buttons)
+	  );
+console.log(this._options.buttons.length + ' ' + this._minW);	  
+	  this._log('#buttons='+this._options.buttons.length+' minWidth='+this._options.minWidth+' _minW='+this._minW);
       this._minH = this._options.minHeight;
       if (this._options.width < this._minW) {
         this._options.width = this._minW;
@@ -293,7 +304,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
       this._resizeMode = '';
       this._initialPlacementDone = false;
       this._raised = false;
-      this._handlingMouseEvent = false;
+	  //## this._handlingMouseEvent = false; //## not used
 
       if (this._options.boundingElement) {
         this._boundingElement = typeof this._options.boundingElement === "string" ? document.querySelector(this._options.boundingElement) : this._options.boundingElement;
@@ -304,13 +315,20 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
       // TODO: fix this magick -- should probably be calculated on first show,
       //  once the buttons are actually rendered
-      this._minW = Math.max(this._minW, (this._buttons.length - 1) * 84 + 13);
-      this._minW = Math.max(this._minW, (this._buttons.length - 1) * 84 + 13);
+      //## this._minW = Math.max(this._minW, (this._buttons.length - 1) * 84 + 13); //## already done
 
       this._shownCount = 0;
     }
 
     ToolWindow.prototype = {
+	  _log: function(text){if(false)console.log(text)}, // show log if true	
+      get title() { //## Allow to set the title	
+        return this._options.title;
+      },
+      set title(value) { //## Allow to set the title	
+        this._options.title = value;
+      },
+	  
       get content() {
         return this._options.content;
       },
@@ -332,7 +350,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
         // TODO: optionally determine initial placement from
         //  a provided event object
 
-        var autoFocus = this._buttons[this._buttons.length - 1];
+        var autoFocus = this._buttons[this._buttons.length - 1]; //## Why the second button from the right?
         if (autoFocus) {
           autoFocus.focus();
         }
@@ -401,6 +419,9 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
       refresh: function refresh() {
         var _this3 = this;
 
+        if (this._options.title && this._options.title != "") { //## Update title
+		  _this3._setTitle(this._options.title);
+		}
         if (!this._options.content) {
           this._setText("No content defined");
           return;
@@ -720,6 +741,13 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
         }
         return current + delta;
       },
+      _setTitle: function _setTitle(text) { //## Set title
+        this._dialogTitleText.innerHTML = "";
+        if (typeof text !== "string") {
+          text = (text || "").toString();
+        }
+        this._dialogTitleText.innerText = text;
+      },
       _setText: function _setText(text) {
         this._dialogContent.innerHTML = "";
         if (typeof text !== "string") {
@@ -782,11 +810,11 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
       },
       _createTitlebar: function _createTitlebar() {
         this._dialogTitle = this._mkDiv("titlebar", this._dialog);
-        this._dialogTitle.innerText = this._options.title;
-
-        this._closeButton = this._mkEl("button", "close", this._dialogTitle);
+        this._closeButton = this._mkEl("button", "close", this._dialogTitle); //##change oder of elements to allow copy to clipboard for content plus title
         this._closeButton.innerText = this._options.closeButtonText;
         this._closeButton.addEventListener("click", this.hide.bind(this));
+        this._dialogTitleText = this._mkEl("span", "", this._dialogTitle); //## Allow to set title
+        this._dialogTitleText.innerText = this._options.title;
       },
       _createContentArea: function _createContentArea() {
         this._dialogContent = this._mkDiv("content", this._dialog);
@@ -884,7 +912,8 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
         }
       },
       _suppressEvent: function _suppressEvent(evt) {
-        if (evt.stopPropagation) {
+		//this._log('_suppressEvent: '+(this._isDrag?' Drag':'')+(this._isResize?' resize=':'')+this._resizeMode+(this._isButton?' Button':''));		
+		if (evt.stopPropagation) {
           evt.stopPropagation();
         }
         if (evt.preventDefault) {
@@ -900,6 +929,11 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
         if (!evt || !evt.target) {
           return;
         }
+		this._log('_onMouseDown: '+(this._isDrag?' Drag':'')+(this._isResize?' resize=':'')+this._resizeMode+(this._isButton?' Button':''));		
+
+		if (evt.target.closest(".dialog>.content") && this._resizeMode === '') { //## Allow normal events on content element
+			return;
+		}
         var rect = this._getOffset(this._dialog);
         this._maxX = Math.max(document.documentElement["clientWidth"], document.body["scrollWidth"], document.documentElement["scrollWidth"], document.body["offsetWidth"], document.documentElement["offsetWidth"]);
         this._maxY = Math.max(document.documentElement["clientHeight"], document.body["scrollHeight"], document.documentElement["scrollHeight"], document.body["offsetHeight"], document.documentElement["offsetHeight"]);
@@ -916,7 +950,9 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
         this._leftPos = rect.left;
         this._topPos = rect.top;
 
-        if (evt.target === this._dialogTitle && this._resizeMode === '') {
+		//## Allow to set title
+        //if (evt.target === this._dialogTitle && this._resizeMode === '') {
+        if ((evt.target === this._dialogTitle || evt.target === this._dialogTitleText) && this._resizeMode === '') {
           this._setCursor('move');
           this._isDrag = true;
         } else if (this._resizeMode !== '') {
@@ -1121,9 +1157,8 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
         if (!evt || !evt.target) {
           return;
         }
-        if (this._handlingMouseEvent) {
-          return;
-        }
+		this._log('_onMouseMove: '+(this._isDrag?' Drag':'')+(this._isResize?' resize':'')+this._resizeMode+(this._isButton?' Button':''));		
+
         if (this._isDrag) {
           this._doDrag(evt);
         } else if (this._isResize) {
@@ -1161,10 +1196,18 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
             this._resizeMode = '';
           }
         }
+		this._log('_onMouseMove: '+(this._isDrag?' Drag':'')+(this._isResize?' resize':'')+this._resizeMode+(this._isButton?' Button':''));		
+       if (!this._isDrag && !this._isResize && this._resizeMode==='' && !this._isButton) { //## Allow normal events like 'extend selection' on content element and events on external objects like 'change slider'
+          return;
+        }
         return this._suppressEvent(evt);
       },
       _onMouseUp: function _onMouseUp(evt) {
         evt = evt || window.event;
+		this._log('_onMouseUp: '+(this._isDrag?' Drag':'')+(this._isResize?' resize':'')+this._resizeMode+(this._isButton?' Button':''));		
+       if (!this._isDrag && !this._isResize && this._resizeMode==='' && !this._isButton) { //## Allow normal events like 'extend selection' on content element and events on external objects like 'change slider'
+          return;
+        }
         if (this._isDrag) {
           this._setCursor('');
           this._isDrag = false;


### PR DESCRIPTION
- Allow to change the title of a window, too.
- Enable select text to allow copy&case of the content and the title of a window.
- Temporary: new comments marked with //##; additional internal function _log as a wrapper for  console.log to show event handling sequence

- Upfront calculation of window width according to count of buttons (with a weird formula)
- The calculation of the minimal width depending on the count of buttons is not correct even if the current formula works somehow (but depends on the amount of text in the content area). The width gets extended in fitContent() -> ctx.self.moveTo() later on.